### PR TITLE
Added undocumented vars for anti-ping

### DIFF
--- a/miscellaneous/variables.mdx
+++ b/miscellaneous/variables.mdx
@@ -64,13 +64,20 @@ icon: "code"
 
 ## Anti-Ping Variables  
 <AccordionGroup>
-   <Accordion title="Author Variables" icon="user">
-| Variable          | Description |  
-|----------------------|----------------------------------------------|  
-| `{author-mention}`  | Displays a mention of the author who sent the message (e.g., `<@123456789012345678>`). |  
-| `{author-username}` | Displays the author's username (e.g., `JohnDoe`). |  
-| `{author-icon}`     | Displays the author's profile picture (avatar URL). |  
-| `{users}`          | Lists the users who were pinged by the author (e.g., `@User1, @User2`). |  
+  <Accordion title="Author Variables" icon="user">
+    | Variable          | Description |  
+    |----------------------|----------------------------------------------|  
+    | `{author-mention}`  | Displays a mention of the author who sent the message (e.g., `<@123456789012345678>`). |  
+    | `{author-username}` | Displays the author's username (e.g., `JohnDoe`). |  
+    | `{author-icon}`     | Displays the author's profile picture (avatar URL). |  
+    | `{users}`          | Lists the users who were pinged by the author (e.g., `@User1, @User2`). |  
+  </Accordion>
+  <Accordion title="Role Variables" icon="user">
+    | Variable          | Description |  
+    |----------------------|----------------------------------------------|  
+    | `{role_name}`  | Display the name of the role the user pinged. (e.g., `Owner`). |  
+    | `{role_id}` | Displays role id of the role the user pinged. (e.g., `123456789012345678`). |  
+    | `{role_mention}`     | Display a mention of the role the user pinged. (e.g., `@Owner`). |  
   </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
`{role_name}`  | Display the name of the role the user pinged. (e.g., `Owner`).
`{role_id}` | Displays role id of the role the user pinged. (e.g., `123456789012345678`).
`{role_mention}`     | Display a mention of the role the user pinged. (e.g., `@Owner`).